### PR TITLE
rustfmt: add import rules

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"


### PR DESCRIPTION
Add nightly rustfmt rules.
As the CI checks agasinst stable rust, it won't be able to check these rules, but devs can use `cargo +nightly fmt`